### PR TITLE
Fix position file output error in KiCAD 8.0

### DIFF
--- a/gerber_drill.py
+++ b/gerber_drill.py
@@ -54,7 +54,8 @@ def GenGerberDrill(board = None, split_G85 = 0.2, plotDir = "plot/", plotReferen
 	popt.SetMirror(False)
 	popt.SetUseGerberAttributes(True)
 	popt.SetUseGerberProtelExtensions(False)
-	popt.SetExcludeEdgeLayer(True)
+	if hasattr(popt, "SetExcludeEdgeLayer"):
+		popt.SetExcludeEdgeLayer(True)
 	popt.SetScale(1)
 	popt.SetUseAuxOrigin(True)
 	popt.SetPlotReference(plotReference)

--- a/loadnet.py
+++ b/loadnet.py
@@ -21,7 +21,10 @@ def loadNet(brd = None):
     return {}
 def parseFootprint(fp):
     r = {}
-    prop = fp.GetProperties()
+    if hasattr(fp, "GetFields"):
+        prop = fp.GetFields()
+    else:
+        prop = fp.GetProperties()
     r['value'] = fp.GetValue()
     r['footprint'] = str(fp.GetFPID().GetLibItemName())
     if "Datasheet" in prop:

--- a/mf_tool.py
+++ b/mf_tool.py
@@ -483,7 +483,10 @@ class POSItem:
             print('Pad1 not found for mod')
             self.PadX = self.MidX
             self.PadY = self.MidY
-        self.rot = int(mod.GetOrientation()/10)
+        if hasattr(mod, "GetOrientationDegrees"):
+            self.rot = int(mod.GetOrientationDegrees())
+        else:
+            self.rot = int(mod.GetOrientation()/10)
         self.ref = mod.GetReference()
         self.val = mod.GetValue()
         self.layer = layerName(mod.GetLayer())
@@ -618,6 +621,7 @@ def GenMFDoc(SplitTopAndBottom = False, ExcludeRef = [], ExcludeValue = [], brd 
         return
     bound = GetBoardBound(brd)
     org_pt = pcbnew.wxPoint( bound.GetLeft(), bound.GetBottom())
+    org_pt = pcbnew.VECTOR2I(org_pt.x, org_pt.y)
     logger("set board aux origin to left bottom point, at", org_pt)
     if hasattr(brd, 'SetAuxOrigin'):
         brd.SetAuxOrigin(org_pt)


### PR DESCRIPTION
Due to API changes in KiCAD 8.0, the following changes must be made to comply with it.

1. footprint GetProperties() -> GetFields()
2. footprint GetOrientation() -> GetOrientationDegrees()
3. org_pt = pcbnew.VECTOR2I(org_pt.x, org_pt.y)

The changes keep compatibility to old versions.

Note that this patch only fixes position file output whereas the Gerber output still has errors in KiCAD 8.0.

Additional push:
Eventually, I removed the last error blockage in kicad cause I did not know what alternative function in 8.0 can help, as follows:
```diff
- popt.SetExcludeEdgeLayer(True)
+ if hasattr(popt, "SetExcludeEdgeLayer"):
+   popt.SetExcludeEdgeLayer(True)
```
The plugin eventually works in KiCAD 8.0.
Anyone find an alternative solution to exclude the edge layer in KiCAD 8.0, please pull request. Thank you!